### PR TITLE
Changes libusb-1.0 static lib reference for Windows build

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -15,9 +15,7 @@
 // Package usb provides a wrapper around libusb-1.0.
 package usb
 
-// #cgo windows CFLAGS: -ID:/lib/libusb-1.0.19/include
-// #cgo windows,amd64 LDFLAGS: D:/lib/libusb-1.0.19/MinGW64/static/libusb-1.0.a
-// #cgo windows,386 LDFLAGS: D:/lib/libusb-1.0.19/MinGW32/static/libusb-1.0.a
+// #cgo windows LDFLAGS: -l:libusb-1.0.a
 // #cgo !windows LDFLAGS: -lusb-1.0
 // #include <libusb-1.0/libusb.h>
 import "C"


### PR DESCRIPTION
The Windows build of the libusb-1.0 wrapper assumes that the static library exists in a hard-coded path that is not portable to all platforms.  Assuming that we're building this in MSYS/MinGW and that the libusb 1.0 package has been downloaded, built and installed, it is more appropriate to reference the libusb-1.0.a static library using the -l:libusb-1.0.a linker flag.