### PR TITLE
Pull in workaround from gousb to handle deprecation of libusb_set_debug

### DIFF
--- a/usb/usb.c
+++ b/usb/usb.c
@@ -1,0 +1,26 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Copyright 2018 the gousb Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libusb-1.0/libusb.h>
+
+void gousb_set_debug(libusb_context *ctx, int lvl) {
+    // TODO(sebek): remove libusb_debug entirely in 2.1 or 3.0,
+    // require libusb >= 1.0.22. libusb 1.0.22 sets API version 0x01000106.
+#if LIBUSB_API_VERSION >= 0x01000106
+    libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, lvl);
+#else
+    libusb_set_debug(ctx, lvl);
+#endif
+}

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -15,8 +15,12 @@
 // Package usb provides a wrapper around libusb-1.0.
 package usb
 
-// #cgo LDFLAGS: -lusb-1.0
-// #include <libusb-1.0/libusb.h>
+/*
+#cgo pkg-config: libusb-1.0
+#include <libusb.h>
+
+void gousb_set_debug(libusb_context *ctx, int lvl);
+*/
 import "C"
 
 import (
@@ -31,7 +35,7 @@ type Context struct {
 }
 
 func (c *Context) Debug(level int) {
-	C.libusb_set_debug(c.ctx, C.int(level))
+	C.gousb_set_debug(c.ctx, C.int(level))
 }
 
 func NewContext() *Context {


### PR DESCRIPTION
before:

cgo-gcc-prolog: In function ‘_cgo_c51feb43ce6c_Cfunc_libusb_set_debug’:
cgo-gcc-prolog:177:2: warning: ‘libusb_set_debug’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
In file included from /home/foo/github.com/thorduri/go-libusb/usb/usb.go:19:
/usr/include/libusb-1.0/libusb.h:1300:18: note: declared here
 void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
                                 ^~~~~~~~~~~~~~~~